### PR TITLE
Add manifest to distFiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,15 @@ module.exports = {
         },
 
         prependPath: '',
-        
+
         excludePaths: ['index.html'],
-        
+
         includePaths: [],
-        
+
         network: ['*'],
-        
+
         fallback: [],
-        
+
         distFiles: function(context) {
           return context.distFiles || [];
         }
@@ -51,41 +51,37 @@ module.exports = {
 
       didPrepare: function(context) {
         this._createManifestFile(context);
-        
+
         var distDir      = this.readConfig('distDir');
         var htmlPagePath = path.join(distDir, 'index.html');
-        
+
         var manifestRoot = this.readConfig('manifestRoot');
         var filename     = this.readConfig('filename');
         var manifestPath = path.join(manifestRoot, filename);
 
-
         this.log('Adding manifest attribute to html tag with value of "' + manifestPath + '".');
-        
-        var modifying = new Promise(function(resolve, reject) {
-          readFile(htmlPagePath).then(
-            function(data) {
-              replaceHtmlManifest(data, manifestPath).then(
-                function(html) {
-                  writeFile(htmlPagePath, html).then(resolve, reject);
-                },
-                reject
-              );
-            },
-            reject
-          );
-        });
 
-        modifying.then(
-          function() {
+        this.log('distDir => ' + distDir, { verbose: true });
+        this.log('htmlPagePath => ' + htmlPagePath, { verbose: true });
+        this.log('manifestRoot => ' + manifestRoot, { verbose: true });
+        this.log('filename => ' + filename, { verbose: true });
+        this.log('manifestPath => ' + manifestPath, { verbose: true });
+
+        return readFile(htmlPagePath)
+          .then(function(data) {
+            return replaceHtmlManifest(data, manifestPath);
+          })
+          .then(function(html) {
+            return writeFile(htmlPagePath, html);
+          })
+          .then(function() {
             this.log('Successfully added manifest attribute to html tag.', { color: 'green' });
-          },
+            return { distFiles: [manifestPath] };
+          }.bind(this),
           function() {
             this.log('Faild to add manifest attribute to html tag.', { color: 'red' });
-          }
-        );
-
-        return modifying;
+            return Promise.reject;
+          }.bind(this));
       },
 
       _createManifestFile: function(context) {

--- a/lib/utilities/replace-html-manifest.js
+++ b/lib/utilities/replace-html-manifest.js
@@ -4,6 +4,8 @@ var RSVP      = require('rsvp');
 module.exports = function(html, manifestPath) {
   var $ = cheerio.load(html.toString());
   $('html').attr('manifest', manifestPath);
-  
-  return new RSVP.resolve($.html());
+
+  return new RSVP.Promise(function(resolve) {
+    resolve($.html(), manifestPath);
+  });
 };


### PR DESCRIPTION
Tried using `ember-cli-deploy-html-manifest` to deploy to S3 but ran into an issue where the manifest file wasn't being uploaded with the rest of the assets.

Came across #1 which should get addressed by this PR.

---
- [x] Refactors Promise resolution to ensure that `distFiles` gets returned from `didPrepare`
